### PR TITLE
Added travis configuration with skeleton deployment

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - "3.6"      # current default Python on Travis CI
+  - "3.7"
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+before_deploy: "echo 'ready?'"
+deploy:
+  on:
+    tags: True
+  provider: heroku
+  api_key:
+    secure: "YOUR ENCRYPTED API KEY"
+after_deploy:
+  - ./after_deploy_1.sh
+  - ./after_deploy_2.sh


### PR DESCRIPTION
@camiloramirezgo - to set up the Heroku deployment, you'll need to add your **encrypted** deployment key, following instructions [here](https://docs.travis-ci.com/user/deployment/heroku/).

We'll also need to adjust the path the `requirements.txt` file after PR #2 is merged in.